### PR TITLE
Add LosslessStringConvertible, RawRepresentable overloads

### DIFF
--- a/Sources/ObservableUserDefaults/Disposable.swift
+++ b/Sources/ObservableUserDefaults/Disposable.swift
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 Bryan Summersett
+
+import Foundation
+
+final class Disposable {
+  let dispose: () -> Void
+
+  init(_ dispose: @escaping () -> Void) {
+    self.dispose = dispose
+  }
+
+  deinit {
+    dispose()
+  }
+}

--- a/Sources/ObservableUserDefaults/KVO.swift
+++ b/Sources/ObservableUserDefaults/KVO.swift
@@ -2,32 +2,6 @@
 
 import Foundation
 
-private final class Disposable {
-  let dispose: () -> Void
-
-  init(_ dispose: @escaping () -> Void) {
-    self.dispose = dispose
-  }
-
-  deinit {
-    dispose()
-  }
-}
-
-extension _KeyValueCodingAndObserving where Self: NSObjectProtocol {
-  /// Observe a given key path property.
-  func observe<Value>(_ keyPath: KeyPath<Self, Value>, options: NSKeyValueObservingOptions = [.new], observer: @escaping (Value) -> Void) -> Any {
-    let token = observe(keyPath, options: options) { _, change in
-      let newValue = change.newValue!
-      observer(newValue)
-    }
-    return Disposable {
-      token.invalidate()
-      _ = self
-    }
-  }
-}
-
 extension NSObject {
   func observe<Value>(keyPath: String, type _: Value.Type? = nil, options: NSKeyValueObservingOptions = [.new], completion: @escaping (Value?) -> Void) -> Any {
     let observer = KeyValueObserver<Value>(object: self, keyPath: keyPath, options: options) { value in

--- a/Sources/ObservableUserDefaults/KVO.swift
+++ b/Sources/ObservableUserDefaults/KVO.swift
@@ -3,7 +3,10 @@
 import Foundation
 
 extension NSObject {
-  func observe<Value>(keyPath: String, type _: Value.Type? = nil, options: NSKeyValueObservingOptions = [.new], completion: @escaping (Value?) -> Void) -> Any {
+  func observe<Value>(keyPath: String,
+                      type _: Value.Type? = nil,
+                      options: NSKeyValueObservingOptions = [.new],
+                      completion: @escaping (Value?) -> Void) -> Any {
     let observer = KeyValueObserver<Value>(object: self, keyPath: keyPath, options: options) { value in
       completion(value)
     }

--- a/Sources/ObservableUserDefaults/KVO.swift
+++ b/Sources/ObservableUserDefaults/KVO.swift
@@ -3,22 +3,22 @@
 import Foundation
 
 extension NSObject {
-  func observe<Value>(keyPath: String,
-                      type _: Value.Type? = nil,
-                      options: NSKeyValueObservingOptions = [.new],
-                      completion: @escaping (Value?) -> Void) -> Any {
-    let observer = KeyValueObserver<Value>(object: self, keyPath: keyPath, options: options) { value in
+  func observe(keyPath: String,
+               options: NSKeyValueObservingOptions = [.new],
+               completion: @escaping (Any?) -> Void) -> Any
+  {
+    let observer = KeyValueObserver(object: self, keyPath: keyPath, options: options) { value in
       completion(value)
     }
     return Disposable { observer.invalidate() }
   }
 }
 
-private final class KeyValueObserver<Value>: NSObject {
+private final class KeyValueObserver: NSObject {
   public init(object: NSObject,
               keyPath: String,
               options: NSKeyValueObservingOptions,
-              callback: @escaping (Value?) -> Void)
+              callback: @escaping (Any?) -> Void)
   {
     self.object = object
     self.keyPath = keyPath
@@ -49,10 +49,8 @@ private final class KeyValueObserver<Value>: NSObject {
       switch change[key] {
       case is NSNull:
         callback(nil)
-      case let value as Value?:
+      case let value:
         callback(value)
-      default:
-        fatalError("Unexpected value")
       }
     } else {
       super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
@@ -63,6 +61,6 @@ private final class KeyValueObserver<Value>: NSObject {
   private var context = 0 // Values don't really matter. Only address is important.
   private let object: NSObject
   private let keyPath: String
-  private let callback: (Value?) -> Void
+  private let callback: (Any?) -> Void
   private let options: NSKeyValueObservingOptions
 }

--- a/Tests/ObservableUserDefaultsTests/BoolUserDefaultsTests.swift
+++ b/Tests/ObservableUserDefaultsTests/BoolUserDefaultsTests.swift
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Bryan Summersett
+
+import ObservableUserDefaults
+import Combine
+import XCTest
+
+class BoolUserDefaultsTests: XCTestCase {
+  @UserDefault(name: "testName") var userDefault: Bool?
+  var cancellables = Set<AnyCancellable>()
+
+  var completion: Subscribers.Completion<Never>?
+  var values: [Bool?] = []
+
+  override func setUp() {
+    userDefault = nil
+  }
+
+  override func tearDown() {
+    cancellables.removeAll()
+    values = []
+    completion = nil
+  }
+
+  func testConvertsBool() {
+    makeValueSink()
+    UserDefaults.standard.setValue("true", forKey: "testName")
+    UserDefaults.standard.setValue("false", forKey: "testName")
+    UserDefaults.standard.setValue(true, forKey: "testName")
+    UserDefaults.standard.setValue("nil", forKey: "testName")
+
+    XCTAssertEqual(values, [true, false, true, nil])
+  }
+}
+
+extension BoolUserDefaultsTests {
+  func makeValueSink() {
+    $userDefault
+      .sink { [unowned self] value in
+        values.append(value)
+      }
+      .store(in: &cancellables)
+  }
+}

--- a/Tests/ObservableUserDefaultsTests/RawRepresentableUserDefaultsTests.swift
+++ b/Tests/ObservableUserDefaultsTests/RawRepresentableUserDefaultsTests.swift
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Bryan Summersett
+
+import ObservableUserDefaults
+import Combine
+import XCTest
+
+class RawRepresentableUserDefaultsTests: XCTestCase {
+
+  enum IntEnum: Int {
+    case one = 1
+    case two = 2
+  }
+
+  @UserDefault(name: "testName") var userDefault: IntEnum?
+  var cancellables = Set<AnyCancellable>()
+
+  var completion: Subscribers.Completion<Never>?
+  var values: [IntEnum?] = []
+
+  override func setUp() {
+    userDefault = nil
+  }
+
+  override func tearDown() {
+    cancellables.removeAll()
+    values = []
+    completion = nil
+  }
+
+  func testConvertsEnum() {
+    makeValueSink()
+    UserDefaults.standard.setValue("1", forKey: "testName")
+    UserDefaults.standard.setValue("2", forKey: "testName")
+
+    UserDefaults.standard.setValue("3", forKey: "testName")
+    UserDefaults.standard.setValue("nonsense", forKey: "testName")
+
+    UserDefaults.standard.setValue(1, forKey: "testName")
+    UserDefaults.standard.setValue(2, forKey: "testName")
+
+    XCTAssertEqual(values, [.one, .two,
+                            nil, nil,
+                            .one, .two])
+  }
+}
+
+extension RawRepresentableUserDefaultsTests {
+  func makeValueSink() {
+    $userDefault
+      .sink { [unowned self] value in
+        values.append(value)
+      }
+      .store(in: &cancellables)
+  }
+}

--- a/Tests/ObservableUserDefaultsTests/UserDefaultsStringTests.swift
+++ b/Tests/ObservableUserDefaultsTests/UserDefaultsStringTests.swift
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 Bryan Summersett
+
+import ObservableUserDefaults
+import Combine
+import XCTest
+
+final class UserDefaultsStringTests: UserDefaultsTests<String> {
+  func testPublisherNoOp() throws {
+    makeValueSink()
+    userDefault = nil
+    XCTAssertEqual(values, [nil])
+  }
+
+  func testPublisherInitialValue() throws {
+    userDefault = "InitialValue"
+    makeValueSink()
+    XCTAssertEqual(values, ["InitialValue"])
+  }
+
+  func testPublisherOnSet() throws {
+    makeValueSink()
+    userDefault = "NewValue"
+
+    XCTAssertEqual(values, [nil, "NewValue"])
+  }
+
+  func testPublisherOnUnset() throws {
+    userDefault = "InitialValue"
+    makeValueSink()
+    userDefault = nil
+    XCTAssertEqual(values, ["InitialValue", nil])
+  }
+
+  func testPublisherInitialValueThenSet() throws {
+    userDefault = "InitialValue"
+    makeValueSink()
+    userDefault = "NewValue"
+    XCTAssertEqual(values, ["InitialValue", "NewValue"])
+  }
+
+  func testSubscribeNoDemand() {
+    userDefault = "InitialValue"
+    let publisher = $userDefault
+    let subscriber = makeSubscriber(demand: .none)
+    publisher.subscribe(subscriber)
+
+    userDefault = "NewValue"
+
+    XCTAssertEqual(completion, nil)
+    XCTAssertEqual(values, [])
+  }
+
+  func testSubscribeUnlimitedDemand() {
+    userDefault = "InitialValue"
+    let publisher = $userDefault
+    let subscriber = makeSubscriber(demand: .unlimited)
+    publisher.subscribe(subscriber)
+
+    userDefault = "NewValue"
+
+    XCTAssertEqual(completion, nil)
+    XCTAssertEqual(values, ["InitialValue", "NewValue"])
+  }
+
+  func testSubscribeMax1Demand() {
+    userDefault = "InitialValue"
+    let publisher = $userDefault
+    let subscriber = makeSubscriber(demand: .max(1))
+    publisher.subscribe(subscriber)
+
+    userDefault = "NewValue"
+
+    XCTAssertEqual(completion, nil)
+    XCTAssertEqual(values, ["InitialValue"])
+  }
+}

--- a/Tests/ObservableUserDefaultsTests/UserDefaultsTests.swift
+++ b/Tests/ObservableUserDefaultsTests/UserDefaultsTests.swift
@@ -4,9 +4,12 @@ import ObservableUserDefaults
 import Combine
 import XCTest
 
-final class UserDefaultsStringTests: XCTestCase {
-  @UserDefault(name: "testName") private var userDefault: String?
-  private var cancellables = Set<AnyCancellable>()
+class UserDefaultsTests<Value>: XCTestCase {
+  @UserDefault(name: "testName") var userDefault: Value?
+  var cancellables = Set<AnyCancellable>()
+
+  var completion: Subscribers.Completion<Never>?
+  var values: [Value?] = []
 
   override func setUp() {
     userDefault = nil
@@ -17,81 +20,9 @@ final class UserDefaultsStringTests: XCTestCase {
     values = []
     completion = nil
   }
-
-  func testPublisherNoOp() throws {
-    makeValueSink()
-    userDefault = nil
-    XCTAssertEqual(values, [nil])
-  }
-
-  func testPublisherInitialValue() throws {
-    userDefault = "InitialValue"
-    makeValueSink()
-    XCTAssertEqual(values, ["InitialValue"])
-  }
-
-  func testPublisherOnSet() throws {
-    makeValueSink()
-    userDefault = "NewValue"
-
-    XCTAssertEqual(values, [nil, "NewValue"])
-  }
-
-  func testPublisherOnUnset() throws {
-    userDefault = "InitialValue"
-    makeValueSink()
-    userDefault = nil
-    XCTAssertEqual(values, ["InitialValue", nil])
-  }
-
-  func testPublisherInitialValueThenSet() throws {
-    userDefault = "InitialValue"
-    makeValueSink()
-    userDefault = "NewValue"
-    XCTAssertEqual(values, ["InitialValue", "NewValue"])
-  }
-
-  private var completion: Subscribers.Completion<Never>?
-  private var values: [String?] = []
-
-  func testSubscribeNoDemand() {
-    userDefault = "InitialValue"
-    let publisher = $userDefault
-    let subscriber = makeSubscriber(demand: .none)
-    publisher.subscribe(subscriber)
-
-    userDefault = "NewValue"
-
-    XCTAssertEqual(completion, nil)
-    XCTAssertEqual(values, [])
-  }
-
-  func testSubscribeUnlimitedDemand() {
-    userDefault = "InitialValue"
-    let publisher = $userDefault
-    let subscriber = makeSubscriber(demand: .unlimited)
-    publisher.subscribe(subscriber)
-
-    userDefault = "NewValue"
-
-    XCTAssertEqual(completion, nil)
-    XCTAssertEqual(values, ["InitialValue", "NewValue"])
-  }
-
-  func testSubscribeMax1Demand() {
-    userDefault = "InitialValue"
-    let publisher = $userDefault
-    let subscriber = makeSubscriber(demand: .max(1))
-    publisher.subscribe(subscriber)
-
-    userDefault = "NewValue"
-
-    XCTAssertEqual(completion, nil)
-    XCTAssertEqual(values, ["InitialValue"])
-  }
 }
 
-private extension UserDefaultsStringTests {
+extension UserDefaultsTests {
   func makeValueSink() {
     $userDefault
       .sink { [unowned self] value in
@@ -100,7 +31,7 @@ private extension UserDefaultsStringTests {
       .store(in: &cancellables)
   }
 
-  func makeSubscriber(demand: Subscribers.Demand) -> (AnySubscriber<String?, Never>) {
+  func makeSubscriber(demand: Subscribers.Demand) -> (AnySubscriber<Value?, Never>) {
     var subscription_ = Subscription?.none // hold until complete
     _ = subscription_ // fix Swift warnings
     return AnySubscriber(receiveSubscription: { subscription in


### PR DESCRIPTION
Previously these overloads were failing when value type conformed to `LosslessStringConvertible` and the underlying data was in String form.